### PR TITLE
Fixes xml CLI sitemap generator

### DIFF
--- a/lib/retriever/fetchsitemap.rb
+++ b/lib/retriever/fetchsitemap.rb
@@ -16,8 +16,6 @@ module Retriever
       @result.uniq!
     end
 
-    private
-
     # produces valid XML sitemap based on page collection fetched.
     # Writes to current directory.
     def gen_xml
@@ -32,6 +30,8 @@ module Retriever
       f.close
       print_file_info(filename)
     end
+
+    private
 
     def print_file_info(filename)
       puts HR

--- a/spec/retriever_spec.rb
+++ b/spec/retriever_spec.rb
@@ -66,4 +66,25 @@ describe 'Fetch' do
       expect(success_resp).to eq(true)
     end
   end
+
+  describe Retriever::FetchSitemap do
+    let(:options) do
+      { limit: 1, progress: false }
+    end
+
+    let(:url) { 'http://www.yahoo.com' }
+
+    let(:removed_sitemap) { FileUtils.rm(Dir.pwd + '/sitemap-yahoo.xml').first }
+
+    subject { described_class.new(url, options) }
+
+    before do
+      subject.gen_xml
+    end
+
+    it 'generates xml' do
+      sitemap_file = removed_sitemap
+      expect(sitemap_file).to match 'sitemap-yahoo.xml'
+    end
+  end
 end


### PR DESCRIPTION
issuing the following command results in an error
```
$ be rr --sitemap XML --progress http://bouncyatlanta.com
/Users/lfender_mbp/source/rubyretriever/lib/retriever/cli.rb:10:in `initialize': private method `gen_xml' called for #<Retriever::FetchSitemap:0x007fe96a178710> (NoMethodError)
	from /Users/lfender_mbp/source/rubyretriever/bin/rr:75:in `new'
	from /Users/lfender_mbp/source/rubyretriever/bin/rr:75:in `block in <top (required)>'
	from /Users/lfender_mbp/source/rubyretriever/bin/rr:58:in `each'
	from /Users/lfender_mbp/source/rubyretriever/bin/rr:58:in `<top (required)>'
	from /Users/lfender_mbp/.gem/ruby/2.1.3/bin/rr:23:in `load'
	from /Users/lfender_mbp/.gem/ruby/2.1.3/bin/rr:23:in `<main>'
```

make `#gen_xml` public and add specs - note, the specs issue a network request and slows down the suite. i didn't look into it much, is there a simpler way to stub the response? 